### PR TITLE
new[] delete[] mismatch

### DIFF
--- a/CppCoreGuidelines.md
+++ b/CppCoreGuidelines.md
@@ -10510,7 +10510,7 @@ We could carefully release the resource before the throw:
         int* p = new int[12];
         // ...
         if (i < 17) {
-            delete p;
+            delete[] p;
             throw Bad {"in f()", i};
         }
         // ...


### PR DESCRIPTION
Must be

```
int* p = new int[12];
delete[] p;
```
